### PR TITLE
Use referenceIds array for cement and squeeze

### DIFF
--- a/casings.json
+++ b/casings.json
@@ -2,7 +2,6 @@
   {
     "kind": "casing",
     "id": "casing-01",
-    "casingId": "1",
     "start": 139.7,
     "end": 202,
     "diameter": 30,
@@ -12,7 +11,6 @@
   {
     "kind": "casing",
     "id": "casing-02",
-    "casingId": "2",
     "start": 139,
     "end": 1389,
     "diameter": 20,
@@ -22,7 +20,6 @@
   {
     "kind": "casing",
     "id": "casing-03",
-    "casingId": "3",
     "start": 140.4,
     "end": 2607,
     "diameter": 13.38,
@@ -32,7 +29,6 @@
   {
     "kind": "casing",
     "id": "casing-04",
-    "casingId": "4",
     "start": 21.14,
     "end": 1800,
     "diameter": 10.75,
@@ -42,7 +38,6 @@
   {
     "kind": "casing",
     "id": "casing-05",
-    "casingId": "5",
     "start": 1800,
     "end": 2507,
     "diameter": 9.63,
@@ -52,7 +47,6 @@
   {
     "kind": "casing",
     "id": "casing-06",
-    "casingId": "6",
     "start": 2507,
     "end": 3435,
     "diameter": 9.63,
@@ -62,7 +56,6 @@
   {
     "kind": "casing",
     "id": "casing-07",
-    "casingId": "7",
     "start": 3335,
     "end": 5070,
     "diameter": 7,

--- a/cement.json
+++ b/cement.json
@@ -1,5 +1,5 @@
 [
-  { "kind": "cement", "id": "cement-01", "casingIds": ["1"], "toc": 143 },
-  { "kind": "cement", "id": "cement-02", "casingIds": ["2"], "toc": 145 },
-  { "kind": "cement", "id": "cement-03", "casingIds": ["3"], "toc": 2207 }
+  { "kind": "cement", "id": "cement-01", "referenceIds": ["casing-01"], "toc": 143 },
+  { "kind": "cement", "id": "cement-02", "referenceIds": ["casing-02"], "toc": 145 },
+  { "kind": "cement", "id": "cement-03", "referenceIds": ["casing-03"], "toc": 2207 }
 ]

--- a/cementSqueeze.json
+++ b/cementSqueeze.json
@@ -2,8 +2,8 @@
   {
     "kind": "cementSqueeze",
     "id": "cementSqueeze-01",
-    "casingIds": [
-      "2"
+    "referenceIds": [
+      "casing-02"
     ],
     "top": 145,
     "bottom": 160


### PR DESCRIPTION
-Remove `casingId` from casings.
-Change referenced strings from `casingIds` to `referenceIds`, as tubing/screen can be cemented in some cases.